### PR TITLE
[Regression] Variables in HTML attributes are encoded, not interpretated

### DIFF
--- a/src/HTLPreAsset.js
+++ b/src/HTLPreAsset.js
@@ -11,6 +11,10 @@
  */
 const HTMLAsset = require('parcel-bundler/src/assets/HTMLAsset');
 
+function isVariable(path) {
+  return (path[0] === '$');
+}
+
 /**
  * Parcel asset that pre-processes the HTL like HTML and rewrites static links.
  */
@@ -26,6 +30,13 @@ class HTLPreAsset extends HTMLAsset {
       return url;
     }
     return super.addURLDependency(url, from, opts);
+  }
+
+  processSingleDependency(path, opts) {
+    if (isVariable(path)) {
+      return path;
+    }
+    return super.processSingleDependency(path, opts);
   }
 
   async generate() {

--- a/src/HTLPreAsset.js
+++ b/src/HTLPreAsset.js
@@ -12,7 +12,7 @@
 const HTMLAsset = require('parcel-bundler/src/assets/HTMLAsset');
 
 function isVariable(path) {
-  return (path[0] === '$');
+  return path.indexOf('${') >= 0;
 }
 
 /**

--- a/test/example/html.htl
+++ b/test/example/html.htl
@@ -9,8 +9,10 @@
     <meta charset="utf-8">
     <link rel="stylesheet" href="bla.css">
     <link rel="stylesheet" href="bla.css"/>
+    <link rel="stylesheet" href="/foo.css">
 </head>
 <body>
     Hello, world! this is a ${it.resource.title}.
+    <img src="${it.resource.path}.logo.png">
 </body>
 </html>

--- a/test/example/html.htl
+++ b/test/example/html.htl
@@ -14,5 +14,6 @@
 <body>
     Hello, world! this is a ${it.resource.title}.
     <img src="${it.resource.path}.logo.png">
+    <img src="icon.${it.resource.style}.png">
 </body>
 </html>

--- a/test/unit/testGeneratedCode.js
+++ b/test/unit/testGeneratedCode.js
@@ -80,6 +80,7 @@ describe('Generated Code Tests', () => {
           resource: {
             title: 'bar',
             path: '/index',
+            style: 'green',
           },
         });
         assert.ok(res, 'no response received');
@@ -89,6 +90,7 @@ describe('Generated Code Tests', () => {
         assert.ok(res.body.match(cssName), 'response body does not link rewrite');
         assert.ok(res.body.match('/foo.css'), 'response body does contain the absolute path reference');
         assert.ok(res.body.match('/index.logo.png'), 'response body does contain the image reference');
+        assert.ok(res.body.match('icon.green.png'), 'response body does contain the image reference');
       });
     });
   });

--- a/test/unit/testGeneratedCode.js
+++ b/test/unit/testGeneratedCode.js
@@ -79,6 +79,7 @@ describe('Generated Code Tests', () => {
         const res = await script.main({
           resource: {
             title: 'bar',
+            path: '/index',
           },
         });
         assert.ok(res, 'no response received');
@@ -86,6 +87,8 @@ describe('Generated Code Tests', () => {
         assert.ok(res.body.match(/Hello, world/), 'response body does not contain expected result');
         assert.ok(res.body.match(/this is a bar/), 'response body does not contain expected result from pre.js');
         assert.ok(res.body.match(cssName), 'response body does not link rewrite');
+        assert.ok(res.body.match('/foo.css'), 'response body does contain the absolute path reference');
+        assert.ok(res.body.match('/index.logo.png'), 'response body does contain the image reference');
       });
     });
   });


### PR DESCRIPTION
PR for #31 (issue does not want to move for now... will update as soon as move is fixed!)

Not fully sure of the consequences of the fix. It works for:
- `<a href="${it.request.path}">${it.request.path}</a>`
- `<a href="/dist${it.request.path}">${it.request.path}</a>`

Will write test on Monday.