### PR TITLE
fix(compiler): clean up global object

### DIFF
--- a/src/HTLAsset.js
+++ b/src/HTLAsset.js
@@ -32,7 +32,9 @@ class HTLAsset extends Asset {
       .includeRuntime(true)
       .withRuntimeVar('content')
       .withRuntimeVar('request')
-      .withRuntimeGlobalName('payload')
+      .withRuntimeVar('context')
+      .withRuntimeVar('payload')
+      .withRuntimeGlobalName('global')
       .withCodeTemplate(template)
       .withSourceMap(true);
 

--- a/src/engine/RuntimeTemplate.js
+++ b/src/engine/RuntimeTemplate.js
@@ -36,9 +36,17 @@ function run(runtime) {
   });
 }
 
-module.exports.main = async function main(resource) {
+module.exports.main = async function main(context) {
+  const global = Object.assign({}, context);
+  global.payload = new Proxy(global, {
+      get: function(obj, prop) {
+        process.emitWarning(`payload.${prop}: The use of the global 'payload' variable is deprecated in HTL. use 'context.${prop}' instead.`);
+        return obj[prop];
+      },
+  });
+  global.context = context;
   const runtime = new Runtime();
-  runtime.setGlobal(resource);
+  runtime.setGlobal(global);
   await run(runtime);
   return {
     response: {


### PR DESCRIPTION
fixes #67 

Causes deprecation warning of `payload` is used in HTL, eg:

```
(node:60779) Warning: payload.content: The use of the global 'payload' variable is deprecated in HTL. use 'context.content' instead.
```